### PR TITLE
major cleanup of logic and tests, updated readme and upped version to…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,20 +34,15 @@ Quick start
         'freeipa_auth.backends.FreeIpaRpcAuthBackend',
     ]
 
-4. Add settings to your settings file like this::
+4. Override settings in your settings file like this::
 
     FREEIPA_AUTH_BACKEND_ENABLED = True
-    FREEIPA_AUTH_SERVER = "ipa.foo.com"
-    FREEIPA_AUTH_FAILOVER_SERVER = "ipa.failover.com"
+    FREEIPA_AUTH_SERVER = "ipa.foo.com" # defaults to None
+    FREEIPA_AUTH_FAILOVER_SERVER = "ipa.failover.com" # defaults to None
     FREEIPA_AUTH_SSL_VERIFY = True
-    FREEIPA_AUTH_UPDATE_USER_GROUPS = True
-    FREEIPA_AUTH_UPDATE_USER_PERMISSIONS = True
-    FREEIPA_AUTH_USER_FLAGS_BY_GROUP = {"is_staff": ["admin"], "is_superuser": ["superuser"]}
-    FREEIPA_AUTH_REQUIRE_GROUP_PREFIX = "foo.django.group."
-    FREEIPA_AUTH_REQUIRE_PERMISSION_PREFIX = "foo.django.permission."
+    FREEIPA_AUTH_UPDATE_USER_GROUPS = True # defaults to None
     FREEIPA_AUTH_ALWAYS_UPDATE_USER = True
-    FREEIPA_AUTH_AUTHORIZE_ALL_USERS = False
-    FREEIPA_AUTH_USER_ATTRS_MAP = {"first_name": "givenname", "email": "mail"}
+    FREEIPA_AUTH_USER_ATTRS_MAP = {"first_name": "givenname", "last_name": "sn", "email": "mail"}
 
 5. Start the development server and visit http://127.0.0.1:8000/admin/
    to login via freeipa rpc authentication.

--- a/README.rst
+++ b/README.rst
@@ -39,8 +39,8 @@ Quick start
     FREEIPA_AUTH_BACKEND_ENABLED = True
     FREEIPA_AUTH_SERVER = "ipa.foo.com" # defaults to None
     FREEIPA_AUTH_FAILOVER_SERVER = "ipa.failover.com" # defaults to None
-    FREEIPA_AUTH_SSL_VERIFY = True
-    FREEIPA_AUTH_UPDATE_USER_GROUPS = True # defaults to None
+    FREEIPA_AUTH_SSL_VERIFY = True # this would be the path to the ssl cert used
+    FREEIPA_AUTH_UPDATE_USER_GROUPS = True # defaults to False
     FREEIPA_AUTH_ALWAYS_UPDATE_USER = True
     FREEIPA_AUTH_USER_ATTRS_MAP = {"first_name": "givenname", "last_name": "sn", "email": "mail"}
 

--- a/freeipa_auth/backends.py
+++ b/freeipa_auth/backends.py
@@ -63,8 +63,6 @@ class FreeIpaRpcAuthBackend(ModelBackend):
                 # If credentials were valid then sync and return the user
                 # Django will handle user sessions from here
                 if logged_in:
-                    if not self.is_authorized(user_session):
-                        return
                     return self.update_user(user_session)
 
             except requests.ConnectionError:

--- a/setup.py
+++ b/setup.py
@@ -9,13 +9,13 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-freeipa-auth',
-    version='1.0.0',
+    version='2.0.0',
     packages=find_packages(),
     include_package_data=True,
     license='BSD License',
     description='A simple django freeipa rpc authentication backend app with a simple server failover solution.',
     long_description=README,
-    tests_require=['pytest', 'pytest-django>=2.9.1,<=3.1.2', 'requests', 'Django >= 1.8.0'],
+    tests_require=['pytest', 'pytest-django>=2.9.1', 'requests', 'Django >= 1.8.0'],
     install_requires=['requests', 'Django >= 1.8.0'],
     extras_require={
         'security': ['pyOpenSSL >= 0.14', 'cryptography>=1.3.4', 'idna>=2.0.0'],

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     license='BSD License',
     description='A simple django freeipa rpc authentication backend app with a simple server failover solution.',
     long_description=README,
-    tests_require=['pytest', 'pytest-django>=2.9.1', 'requests', 'Django >= 1.8.0'],
+    tests_require=['pytest', 'pytest-django>=2.9.1,<=3.1.2', 'requests', 'Django >= 1.8.0'],
     install_requires=['requests', 'Django >= 1.8.0'],
     extras_require={
         'security': ['pyOpenSSL >= 0.14', 'cryptography>=1.3.4', 'idna>=2.0.0'],


### PR DESCRIPTION
Remove logic that applies permissions from freeipa so services have full control over group perms, remove prefix settings so full group names must match in freeipa, update attributes so last name is pulled from freeipa in addition to email and first name. Users should all get staff access and no one should get superuser access now. README updated, and setup version bumped to 2.0.0