### PR TITLE
Fix Failover Server Logic and Group Updating

### DIFF
--- a/freeipa_auth/backends.py
+++ b/freeipa_auth/backends.py
@@ -132,8 +132,7 @@ class FreeIpaRpcAuthBackend(ModelBackend):
 
         # Update user groups
         if self.settings.UPDATE_USER_GROUPS:
-            all_groups = Group.objects.all()
-            user.groups.remove(*all_groups)
+            user.groups.clear()
             user.groups.add(*Group.objects.filter(name__in=groups))
 
 

--- a/freeipa_auth/tests/conftest.py
+++ b/freeipa_auth/tests/conftest.py
@@ -37,6 +37,18 @@ def test_group(request, db):
 
 
 @pytest.fixture
+def test_group2(request, db):
+    """Fixture for a django test group"""
+    group = Group.objects.create(name="test_group2")
+
+    def fin():
+        group.delete()
+    request.addfinalizer(fin)
+
+    return group
+
+
+@pytest.fixture
 def test_permission(request, db):
     """Fixture for a django test permission"""
 
@@ -114,3 +126,22 @@ def liveserver_password(request, db):
 def liveserver(request, db):
     """Fixture to use a liveserver for testing (passed in from command line)"""
     return request.config.getoption('liveserver')
+
+
+@pytest.fixture
+def mock_user_session_data(request, db, test_user, test_group, test_group2):
+    class UserSessionData(object):
+        def __init__(self, **kwargs):
+            for key in kwargs:
+                setattr(self, key, kwargs[key])
+
+
+    return UserSessionData(
+        user=test_user.username,
+        user_data={
+            "givenname": "Chester",
+            "sn": "Tester",
+            "mail": "chester@test.com"
+        },
+        groups=[test_group.name, test_group2.name]
+    )

--- a/freeipa_auth/tests/test_backends.py
+++ b/freeipa_auth/tests/test_backends.py
@@ -5,7 +5,7 @@ from unittest import mock
 from django.test import override_settings
 from django.contrib.auth import backends
 
-from freeipa_auth.backends import FreeIpaRpcAuthBackend
+from freeipa_auth.backends import FreeIpaRpcAuthBackend, FreeIpaAuthSettings
 
 
 class TestFreeIpaRpcAuthBackend:
@@ -77,3 +77,74 @@ class TestFreeIpaRpcAuthBackend:
             ),
         ]
 
+    def test_update_user_groups_staff_flag(self, test_user):
+        backend = FreeIpaRpcAuthBackend()
+        assert not test_user.is_staff
+        backend.update_user_groups(test_user, [])
+        assert test_user.is_staff
+    
+    def test_update_user_groups_no_change_if_flag_missing(self,test_user, test_group):
+        backend = FreeIpaRpcAuthBackend()
+        assert test_user.groups.all().count() == 0
+        backend.update_user_groups(test_user, [test_group.name])
+        assert test_user.groups.all().count() == 0
+    
+    @override_settings(
+        FREEIPA_AUTH_UPDATE_USER_GROUPS=True
+    )
+    def test_update_user_groups_flag_set(self, test_user, test_group, test_group2):
+        backend = FreeIpaRpcAuthBackend()
+        assert test_user.groups.all().count() == 0
+        backend.update_user_groups(test_user, [test_group.name, test_group2])
+        assert test_user.groups.all().count() == 2
+        backend.update_user_groups(test_user, [test_group.name])
+        assert test_user.groups.all().count() == 1
+
+    def test_update_user_attrs(self, test_user, mock_user_session_data):
+        backend = FreeIpaRpcAuthBackend()
+        assert test_user.first_name == ""
+        assert test_user.last_name == ""
+        assert test_user.email == ""
+        test_data = mock_user_session_data.user_data
+        backend.update_user_attrs(test_user, test_data)
+        assert test_user.first_name == test_data["givenname"]
+        assert test_user.last_name == test_data["sn"]
+        assert test_user.email == test_data["mail"]
+
+    @mock.patch('freeipa_auth.backends.FreeIpaRpcAuthBackend.update_user_attrs')
+    @mock.patch('freeipa_auth.backends.FreeIpaRpcAuthBackend.update_user_groups')
+    def test_update_user(self, mock_update_user_groups, mock_update_user_attrs, test_user, mock_user_session_data):
+        backend = FreeIpaRpcAuthBackend()
+        password = test_user.password
+        backend.update_user(mock_user_session_data)
+        assert not test_user.check_password(password)
+        assert mock_update_user_attrs.called_with(test_user, mock_user_session_data.user_data)
+        assert mock_update_user_groups.called_with(test_user, mock_user_session_data.groups)
+
+    @override_settings(
+        FREEIPA_AUTH_ALWAYS_UPDATE_USER=False
+    )
+    @mock.patch('freeipa_auth.backends.FreeIpaRpcAuthBackend.update_user_attrs')
+    @mock.patch('freeipa_auth.backends.FreeIpaRpcAuthBackend.update_user_groups')
+    def test_update_user_no_update(self, mock_update_user_groups, mock_update_user_attrs, mock_user_session_data):
+        backend = FreeIpaRpcAuthBackend()
+        backend.update_user(mock_user_session_data)
+        mock_update_user_attrs.assert_not_called()
+        mock_update_user_groups.assert_not_called()
+class TestFreeIpaAuthSettings:
+    @override_settings(
+        FREEIPA_AUTH_SERVER="ipa.foo.com",
+        FREEIPA_AUTH_SSL_VERIFY="/path/to/ssl", 
+    )
+    def test_no_failover_set_warning(self, caplog):
+        FreeIpaAuthSettings()
+        assert 'FreeIPA Failover Server is not set. Proceed with caution.' in caplog.text
+
+    @override_settings(
+        FREEIPA_AUTH_SERVER="ipa.foo.com",
+        FREEIPA_AUTH_FAILOVER_SERVER="ipa.failover.com",
+        FREEIPA_AUTH_SSL_VERIFY="/path/to/ssl", 
+    )
+    def test_failover_set_no_warning(self, caplog):
+        FreeIpaAuthSettings()
+        assert 'FreeIPA Failover Server is not set. Proceed with caution.' not in caplog.text

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ exclude = */tests/*
 deps =
     pytest-cov>=2.0.0,<3.0
     flake8>=3.3.0
-    pytest>=3.1.2,<3.2
+    pytest>=3.1.2,<=4.6.1
     pytest-django>=2.9.1,<3.2
     requests>=2.6.1,<2.19
     django22: Django>=2.2,<3.0


### PR DESCRIPTION
Failover server logic wasn't working due to username and password not being passed in as kwargs in the recursive call. Groups were being updated, but then removed right afterwards. Added a ton of missing tests for backend functionality.