### PR TITLE
add a timeout for the auth request

### DIFF
--- a/freeipa_auth/freeipa_utils.py
+++ b/freeipa_auth/freeipa_utils.py
@@ -58,7 +58,8 @@ class FreeIpaSession(object):
             ipa_login_url,
             headers=self.login_headers,
             data=login_data,
-            verify=self.ssl_verify
+            verify=self.ssl_verify,
+            timeout=5
         )
 
         self.user = user
@@ -101,7 +102,8 @@ class FreeIpaSession(object):
             ipa_session_url,
             headers=self.session_headers,
             data=json.dumps(self.session_post_data),
-            verify=self.ssl_verify
+            verify=self.ssl_verify,
+            timeout=5
         )
 
         results = request.json()


### PR DESCRIPTION
Adds a timeout to the authentication request to the freeipa server. Currently, if the server is unavailable or stopped, the request connection doesn't close until much longer than traditional uwsgi and nginx timeouts, causing 504s.